### PR TITLE
configurable colors for printed todo list

### DIFF
--- a/TodoListPlugin.scala
+++ b/TodoListPlugin.scala
@@ -6,12 +6,13 @@ import scala.util.matching.Regex
 
 object TodoListPlugin extends AutoPlugin {
   
-  import scala.Console._
-  
   object autoImport {
     lazy val todos = taskKey[Unit]("Finds and prints 'work in progress' tags (TODO, FIXME, ...) to the console")
     lazy val todosTags = settingKey[Set[String]]("Tags to look for")
-    lazy val todosColors = settingKey[TodoList.Colors]("Colors to use when printing the list")
+    lazy val todosColorFilename = settingKey[String]("Color to use when printing filename")
+    lazy val todosColorLineNumber = settingKey[String]("Color to use when printing line number")
+    lazy val todosColorLine = settingKey[String]("Color to use when printing line")
+    
   }
 
   import autoImport._
@@ -22,14 +23,19 @@ object TodoListPlugin extends AutoPlugin {
   // add the task and a set of default tags
   override def projectSettings = Seq(
     todosTags := Set("FIXME", "TODO", "WIP", "XXX"),
-    // todosColors := TodoList.Colors(BLUE, RED, YELLOW), // original colors
-    todosColors := TodoList.Colors(CYAN, RED, YELLOW), // more readable
+    todosColorFilename := TodoList.defaultColors.filename,
+    todosColorLineNumber := TodoList.defaultColors.lineNumber,
+    todosColorLine := TodoList.defaultColors.line,   
     todos := {
       TodoList(
           baseDirectory.value,
           (sources in Compile).value ++ (sources in Test).value,
           (todosTags in todos).value,
-          (todosColors in todos).value)
+          TodoList.Colors(
+              (todosColorFilename in todos).value,
+              (todosColorLineNumber in todos).value,
+              (todosColorLine in todos).value))
+          
     }
   )
 
@@ -49,6 +55,8 @@ object TodoList {
   import scala.io.Source
 
   case class Colors(filename: String, lineNumber: String, line: String)
+  
+  val defaultColors = Colors(CYAN, RED, YELLOW)
   
   private def highlight(msg: String, color: String) =
     s"$color$msg$RESET"


### PR DESCRIPTION
I wanted to be able to change the color that the filename is printed with, so I added an object to the settings that holds colors to use for the filename, line number, and line.

I don't know what the best scope for the Colors class is. It would be nice if it was easier to change in `build.sbt`. As is, I think you have to do something like this:

`todosColors := com.github.fedragon.TodoList.Colors(scala.Console.RED, scala.Console.GREEN, scala.Console.BLUE)`

Thanks for writing this plugin! It's very useful, and by looking at it I learned a lot about sbt and sbt plugins.
